### PR TITLE
DTOSS-8695: Create initial docker-compose file and Azure Service Bus emulator with test scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ MSSQL_SA_PASSWORD=""
 
 # 4. Time in seconds to wait for SQL to be ready (default is 15 seconds)
 SQL_WAIT_INTERVAL=20
+
+# 5. This is the connection string that is used to allow producers and consumers to connect to the service bus
+SERVICE_BUS_CONNECTION_STR=""

--- a/.env.example
+++ b/.env.example
@@ -16,4 +16,5 @@ MSSQL_SA_PASSWORD=""
 SQL_WAIT_INTERVAL=20
 
 # 5. This is the connection string that is used to allow producers and consumers to connect to the service bus
+# An example of what can be used is available [https://learn.microsoft.com/en-us/azure/service-bus-messaging/test-locally-with-service-bus-emulator?tabs=docker-linux-container#:~:text=2.To%20spin%20up%20containers%20for%20Service%20Bus%20emulator%2C%20save%20the%20following%20.yaml%20file%20as%20docker%2Dcompose.yaml], though we cannot include it directly due to secret scanning restrictions on this repo.
 SERVICE_BUS_CONNECTION_STR=""

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Environment file for user defined variables in docker-compose.yml
+
+# 1. CONFIG_PATH: Path to Config.json file
+# Ex: CONFIG_PATH="C:\\Config\\Config.json"
+CONFIG_PATH=""
+
+# 2. ACCEPT_EULA: Pass 'Y' to accept license terms for Azure SQL Edge and Azure Service Bus emulator.
+# Service Bus emulator EULA : https://github.com/Azure/azure-service-bus-emulator-installer/blob/main/EMULATOR_EULA.txt
+# SQL Edge EULA : https://go.microsoft.com/fwlink/?linkid=2139274
+ACCEPT_EULA="N"
+
+# 3. MSSQL_SA_PASSWORD to be filled by user as per policy : https://learn.microsoft.com/en-us/sql/relational-databases/security/strong-passwords?view=sql-server-linux-ver16
+MSSQL_SA_PASSWORD: ""
+
+# 4. Time in seconds to wait for SQL to be ready (default is 15 seconds)
+SQL_WAIT_INTERVAL: 20

--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ CONFIG_PATH=""
 ACCEPT_EULA="N"
 
 # 3. MSSQL_SA_PASSWORD to be filled by user as per policy : https://learn.microsoft.com/en-us/sql/relational-databases/security/strong-passwords?view=sql-server-linux-ver16
-MSSQL_SA_PASSWORD: ""
+MSSQL_SA_PASSWORD=""
 
 # 4. Time in seconds to wait for SQL to be ready (default is 15 seconds)
-SQL_WAIT_INTERVAL: 20
+SQL_WAIT_INTERVAL=20

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *vulnerabilities*report*.json
 *report*json.zip
 .version
+.env
 
 *.code-workspace
 !project.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *vulnerabilities*report*.json
 *report*json.zip
 .version
+venv/
 .env
 
 *.code-workspace

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,18 @@ config:: # Configure development environment (main) @Configuration
 	# TODO: Use only 'make' targets that are specific to this project, e.g. you may not need to install Node.js
 	make _install-dependencies
 
+# Custom targets for local development and testing
+
+standup-local-containers: # Start all containers defined in docker-compose.yaml
+	@echo "Starting all containers using Podman Compose..."
+	podman-compose up -d
+	@echo "All containers are now running."
+
+shutdown-local-containers: # Shutdown all containers defined in docker-compose.yaml
+	@echo "Shutdown all containers using Podman Compose..."
+	podman-compose down
+	@echo "All containers are now down."
+
 # ==============================================================================
 
 ${VERBOSE}.SILENT: \
@@ -34,3 +46,5 @@ ${VERBOSE}.SILENT: \
 	config \
 	dependencies \
 	deploy \
+
+

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Run the producer script
 This sends a test message to the queue.
 
 ```shell
-(venv) % python3 service-bus-producer.py
+(venv) % python3 scripts/docker/service-bus-producer.py
 Message sent.
 (venv) %
 ```
@@ -118,7 +118,7 @@ Run the consumer script
 This will pick up and display the message.
 
 ```shell
-(venv) % python3 service-bus-consumer.py
+(venv) % python3 scripts/docker/service-bus-consumer.py
 Listening for messages...
 Received: Hello from local sender!
 ```

--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ There is a requirement to allow us to be able to test out the analyse data pipel
 podman-compose -f docker-compose.yaml up -d
 ```
 
-This should bring up two services, both sqledge and servicebus-emulator: -
+This should bring up two services, both `sqledge` and `servicebus-emulator`: -
 
 ```shell
-alastairlock@Alastairs-MacBook-Pro dtos-analyse-data-pipeline % podman ps
+% podman ps
 CONTAINER ID  IMAGE                                                         COMMAND               CREATED      STATUS      PORTS                                                     NAMES
 e4c9e73d3610  mcr.microsoft.com/mssql/server:2022-latest                    /opt/mssql/bin/sq...  4 hours ago  Up 4 hours  1433/tcp                                                  sqledge
 7226f76cd694  mcr.microsoft.com/azure-messaging/servicebus-emulator:latest                        4 hours ago  Up 4 hours  0.0.0.0:5300->5300/tcp, 0.0.0.0:5672->5672/tcp, 8080/tcp  servicebus-emulator
@@ -105,23 +105,55 @@ If the components have been successfully deployed, you can test the setup using 
 service-bus-producer.py: Sends a message to queue.1 on the Azure Service Bus emulator.
 service-bus-consumer.py: Listens for and receives messages from queue.1.
 
-
-1. Run the producer script
+Run the producer script
 This sends a test message to the queue.
 
 ```shell
-(venv) alastairlock@Alastairs-MacBook-Pro docker % python3 service-bus-producer.py
+(venv) % python3 service-bus-producer.py
 Message sent.
-(venv) alastairlock@Alastairs-MacBook-Pro docker %
+(venv) %
 ```
 
-2. Run the consumer script
+Run the consumer script
 This will pick up and display the message.
 
 ```shell
-(venv) alastairlock@Alastairs-MacBook-Pro docker % python3 service-bus-consumer.py
+(venv) % python3 service-bus-consumer.py
 Listening for messages...
 Received: Hello from local sender!
+```
+
+Please note that it might be necessary to purge the docker images between starting and stopping `podman-compose`. This can be achieved via doing commands:-
+
+```shell
+(venv) % podman-compose -f docker-compose.yaml down
+servicebus-emulator
+sqledge
+servicebus-emulator
+sqledge
+af571ddd5671ac646e503ccea11b8fde16edc7ad65a918e7af1d7d4a29d4d434
+microsoft-azure-servicebus-emulator_sb-emulator
+(venv) %
+```
+
+Then find the image IDs which need to be removed: -
+
+```shell
+(venv) % podman images
+REPOSITORY                                             TAG          IMAGE ID      CREATED       SIZE
+mcr.microsoft.com/azure-messaging/servicebus-emulator  latest       77e64bec8af0  8 weeks ago   225 MB
+mcr.microsoft.com/mssql/server                         2022-latest  2b41d0be8283  2 months ago  1.66 GB
+```
+
+Then remove the images using command `podman image rm <IMAGE ID>`
+
+```shell
+(venv) % podman image rm 77e64bec8af0 2b41d0be8283
+Untagged: mcr.microsoft.com/azure-messaging/servicebus-emulator:latest
+Untagged: mcr.microsoft.com/mssql/server:2022-latest
+Deleted: 77e64bec8af06eee8ba4952311cd16b9e360b8da1d3a9f501191ac1ba4f11f74
+Deleted: 2b41d0be82839692f678a709e8b7dd6106ee4776b0e70759c59b067730058b04
+
 ```
 
 ## Design

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Make use of this repository template to expedite your project setup and enhance 
     - [Configuration](#configuration)
   - [Usage](#usage)
     - [Testing](#testing)
+    - [Azure Service Bus docker emulator](#azure-service-bus-docker-emulator)
   - [Design](#design)
     - [Diagrams](#diagrams)
     - [Modularity](#modularity)
@@ -82,6 +83,46 @@ After a successful installation, provide an informative example of how this proj
 ### Testing
 
 There are `make` tasks for you to configure to run your tests.  Run `make test` to see how they work.  You should be able to use the same entry points for local development as in your CI pipeline.
+
+### Azure Service Bus docker emulator
+
+There is a requirement to allow us to be able to test out the analyse data pipeline locally. To do this we have created an Azure Service bus emulator. To test this out you will have to run: -
+
+```shell
+podman-compose -f docker-compose.yaml up -d
+```
+
+This should bring up two services, both sqledge and servicebus-emulator: -
+
+```shell
+alastairlock@Alastairs-MacBook-Pro dtos-analyse-data-pipeline % podman ps
+CONTAINER ID  IMAGE                                                         COMMAND               CREATED      STATUS      PORTS                                                     NAMES
+e4c9e73d3610  mcr.microsoft.com/mssql/server:2022-latest                    /opt/mssql/bin/sq...  4 hours ago  Up 4 hours  1433/tcp                                                  sqledge
+7226f76cd694  mcr.microsoft.com/azure-messaging/servicebus-emulator:latest                        4 hours ago  Up 4 hours  0.0.0.0:5300->5300/tcp, 0.0.0.0:5672->5672/tcp, 8080/tcp  servicebus-emulator
+```
+
+If the components have been successfully deployed, you can test the setup using two Python scripts located in the scripts/docker directory:
+service-bus-producer.py: Sends a message to queue.1 on the Azure Service Bus emulator.
+service-bus-consumer.py: Listens for and receives messages from queue.1.
+
+
+1. Run the producer script
+This sends a test message to the queue.
+
+```shell
+(venv) alastairlock@Alastairs-MacBook-Pro docker % python3 service-bus-producer.py
+Message sent.
+(venv) alastairlock@Alastairs-MacBook-Pro docker %
+```
+
+2. Run the consumer script
+This will pick up and display the message.
+
+```shell
+(venv) alastairlock@Alastairs-MacBook-Pro docker % python3 service-bus-consumer.py
+Listening for messages...
+Received: Hello from local sender!
+```
 
 ## Design
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,107 @@
+{
+  "UserConfig": {
+    "Namespaces": [
+      {
+        "Name": "sbemulatorns",
+        "Queues": [
+          {
+            "Name": "queue.1",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "DuplicateDetectionHistoryTimeWindow": "PT20S",
+              "ForwardDeadLetteredMessagesTo": "",
+              "ForwardTo": "",
+              "LockDuration": "PT1M",
+              "MaxDeliveryCount": 10,
+              "RequiresDuplicateDetection": false,
+              "RequiresSession": false
+            }
+          }
+        ],
+        "Topics": [
+          {
+            "Name": "topic.1",
+            "Properties": {
+              "DefaultMessageTimeToLive": "PT1H",
+              "DuplicateDetectionHistoryTimeWindow": "PT20S",
+              "RequiresDuplicateDetection": false
+            },
+            "Subscriptions": [
+              {
+                "Name": "subscription.1",
+                "Properties": {
+                  "DeadLetteringOnMessageExpiration": false,
+                  "DefaultMessageTimeToLive": "PT1H",
+                  "LockDuration": "PT1M",
+                  "MaxDeliveryCount": 10,
+                  "ForwardDeadLetteredMessagesTo": "",
+                  "ForwardTo": "",
+                  "RequiresSession": false
+                },
+                "Rules": [
+                  {
+                    "Name": "app-prop-filter-1",
+                    "Properties": {
+                      "FilterType": "Correlation",
+                      "CorrelationFilter": {
+                        "ContentType": "application/text",
+                        "CorrelationId": "id1",
+                        "Label": "subject1",
+                        "MessageId": "msgid1",
+                        "ReplyTo": "someQueue",
+                        "ReplyToSessionId": "sessionId",
+                        "SessionId": "session1",
+                        "To": "xyz"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "Name": "subscription.2",
+                "Properties": {
+                  "DeadLetteringOnMessageExpiration": false,
+                  "DefaultMessageTimeToLive": "PT1H",
+                  "LockDuration": "PT1M",
+                  "MaxDeliveryCount": 10,
+                  "ForwardDeadLetteredMessagesTo": "",
+                  "ForwardTo": "",
+                  "RequiresSession": false
+                },
+                "Rules": [
+                  {
+                    "Name": "user-prop-filter-1",
+                    "Properties": {
+                      "FilterType": "Correlation",
+                      "CorrelationFilter": {
+                        "Properties": {
+                          "prop1": "value1"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "Name": "subscription.3",
+                "Properties": {
+                  "DeadLetteringOnMessageExpiration": false,
+                  "DefaultMessageTimeToLive": "PT1H",
+                  "LockDuration": "PT1M",
+                  "MaxDeliveryCount": 10,
+                  "ForwardDeadLetteredMessagesTo": "",
+                  "ForwardTo": "",
+                  "RequiresSession": false
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Logging": {
+      "Type": "File"
+    }
+  }
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,33 @@
+name: microsoft-azure-servicebus-emulator
+services:
+  emulator:
+    container_name: "servicebus-emulator"
+    image: mcr.microsoft.com/azure-messaging/servicebus-emulator:latest
+    volumes:
+      - "${CONFIG_PATH}:/ServiceBus_Emulator/ConfigFiles/Config.json"
+    ports:
+      - "5672:5672"
+      - "5300:5300"
+    environment:
+      SQL_SERVER: sqledge
+      MSSQL_SA_PASSWORD: ${MSSQL_SA_PASSWORD}
+      ACCEPT_EULA: ${ACCEPT_EULA}
+      SQL_WAIT_INTERVAL: ${SQL_WAIT_INTERVAL}
+    depends_on:
+      - sqledge
+    networks:
+      sb-emulator:
+        aliases:
+          - "sb-emulator"
+  sqledge:
+        container_name: "sqledge"
+        image: "mcr.microsoft.com/azure-sql-edge:latest"
+        networks:
+          sb-emulator:
+            aliases:
+              - "sqledge"
+        environment:
+          ACCEPT_EULA: ${ACCEPT_EULA}
+          MSSQL_SA_PASSWORD: ${MSSQL_SA_PASSWORD}
+networks:
+  sb-emulator:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,9 @@ services:
           - "sb-emulator"
   sqledge:
         container_name: "sqledge"
-        image: "mcr.microsoft.com/azure-sql-edge:latest"
+        # Azure-sql-edge has problems, instead use server:2022
+        # image: "mcr.microsoft.com/azure-sql-edge:latest"
+        image: mcr.microsoft.com/mssql/server:2022-latest
         networks:
           sb-emulator:
             aliases:

--- a/scripts/docker/service-bus-consumer.py
+++ b/scripts/docker/service-bus-consumer.py
@@ -1,0 +1,26 @@
+import os
+import time
+from dotenv import load_dotenv
+from azure.servicebus import ServiceBusClient, ServiceBusMessage
+
+load_dotenv()
+
+connection_str = os.getenv("SERVICE_BUS_CONNECTION_STR")
+if not connection_str:
+    raise ValueError("Missing SERVICE_BUS_CONNECTION_STR in .env file")
+
+client = ServiceBusClient.from_connection_string(connection_str)
+
+with client:
+    receiver = client.get_queue_receiver(queue_name="queue.1", max_wait_time=5)
+    with receiver:
+        print("Listening for messages...")
+        while True:
+            messages = receiver.receive_messages(max_message_count=10)
+            if not messages:
+                time.sleep(1)
+                continue
+
+            for msg in messages:
+                print("Received:", str(msg))
+                receiver.complete_message(msg)

--- a/scripts/docker/service-bus-producer.py
+++ b/scripts/docker/service-bus-producer.py
@@ -1,0 +1,17 @@
+import os
+from dotenv import load_dotenv
+from azure.servicebus import ServiceBusClient, ServiceBusMessage
+
+load_dotenv()
+
+connection_str = os.getenv("SERVICE_BUS_CONNECTION_STR")
+if not connection_str:
+    raise ValueError("Missing SERVICE_BUS_CONNECTION_STR in .env file")
+client = ServiceBusClient.from_connection_string(connection_str)
+
+with client:
+    sender = client.get_queue_sender(queue_name="queue.1")
+    with sender:
+        message = ServiceBusMessage("Hello from local sender!")
+        sender.send_messages(message)
+        print("Message sent.")


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This is the very first building block to create local version of Azure Service Bus. This will be used to test out the pipeline process to get data into the FDP application.

There is a requirement to allow us to be able to test out the analyse data pipeline locally. To do this we have created an Azure Service bus emulator. To test this out you will have to run: -

```shell
podman-compose -f docker-compose.yaml up -d
```

This should bring up two services, both sqledge and servicebus-emulator: -

```shell
% podman ps
CONTAINER ID  IMAGE                                                         COMMAND               CREATED      STATUS      PORTS                                                     NAMES
e4c9e73d3610  mcr.microsoft.com/mssql/server:2022-latest                    /opt/mssql/bin/sq...  4 hours ago  Up 4 hours  1433/tcp                                                  sqledge
7226f76cd694  mcr.microsoft.com/azure-messaging/servicebus-emulator:latest                        4 hours ago  Up 4 hours  0.0.0.0:5300->5300/tcp, 0.0.0.0:5672->5672/tcp, 8080/tcp  servicebus-emulator
```

If the components have been successfully deployed, you can test the setup using two Python scripts located in the scripts/docker directory:
service-bus-producer.py: Sends a message to queue.1 on the Azure Service Bus emulator.
service-bus-consumer.py: Listens for and receives messages from queue.1.


1. Run the producer script
This sends a test message to the queue.

```shell
(venv) % python3 service-bus-producer.py
Message sent.
(venv) %
```

2. Run the consumer script
This will pick up and display the message.

```shell
(venv) % python3 service-bus-consumer.py
Listening for messages...
Received: Hello from local sender!
```

Please note that it might be necessary to purge the docker images between starting and stopping podman compose. This can be achieved via doing commands:-

```shell
(venv) % podman-compose -f docker-compose.yaml down
servicebus-emulator
sqledge
servicebus-emulator
sqledge
af571ddd5671ac646e503ccea11b8fde16edc7ad65a918e7af1d7d4a29d4d434
microsoft-azure-servicebus-emulator_sb-emulator
(venv) %
```

Then find the image IDs which need to be removed: -

```shell
(venv) % podman images
REPOSITORY                                             TAG          IMAGE ID      CREATED       SIZE
mcr.microsoft.com/azure-messaging/servicebus-emulator  latest       77e64bec8af0  8 weeks ago   225 MB
mcr.microsoft.com/mssql/server                         2022-latest  2b41d0be8283  2 months ago  1.66 GB
```

Then remove the images using command `podman image rm <IMAGE ID>`

```shell
(venv) % podman image rm 77e64bec8af0 2b41d0be8283
Untagged: mcr.microsoft.com/azure-messaging/servicebus-emulator:latest
Untagged: mcr.microsoft.com/mssql/server:2022-latest
Deleted: 77e64bec8af06eee8ba4952311cd16b9e360b8da1d3a9f501191ac1ba4f11f74
Deleted: 2b41d0be82839692f678a709e8b7dd6106ee4776b0e70759c59b067730058b04

```

![image](https://github.com/user-attachments/assets/42f5efad-2216-48d9-8e82-870f88dd1302)


<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
