### PR TITLE
DTOSS-0000: Put Service Bus Connection String back in for local dev

### DIFF
--- a/infrastructure/environments/cloud/tf-core/environments/development.tfvars
+++ b/infrastructure/environments/cloud/tf-core/environments/development.tfvars
@@ -177,6 +177,7 @@ function_apps = {
       env_vars_static = {
         TOPIC_NAME               = "events"
         FUNCTIONS_WORKER_RUNTIME = "python"
+        USE_MANAGED_IDENTITY     = true
       }
     }
 

--- a/src/function_apps/service_layer/service_layer/service_layer.py
+++ b/src/function_apps/service_layer/service_layer/service_layer.py
@@ -28,14 +28,23 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
             raise EnvironmentError("Service Bus topic name is missing.")
 
         # Create ServiceBusClient
-        logger.info("Connecting to the Service Bus via Managed Identity.")
+        if use_managed_identity:
+            logger.info("Connecting to the Service Bus via Managed Identity.")
 
-        fully_qualified_namespace = os.getenv("SERVICE_BUS_NAMESPACE")
-        if not fully_qualified_namespace:
-            raise EnvironmentError("SERVICE_BUS_NAMESPACE is required when using managed identity.")
-        logger.info("Using Managed Identity for Service Bus authentication.")
-        credential = DefaultAzureCredential()
-        client = ServiceBusClient(fully_qualified_namespace=fully_qualified_namespace, credential=credential)
+            fully_qualified_namespace = os.getenv("SERVICE_BUS_NAMESPACE")
+            if not fully_qualified_namespace:
+                raise EnvironmentError("SERVICE_BUS_NAMESPACE is required when using managed identity.")
+            logger.info("Using Managed Identity for Service Bus authentication.")
+            credential = DefaultAzureCredential()
+            client = ServiceBusClient(fully_qualified_namespace=fully_qualified_namespace, credential=credential)
+        else:
+            # Validate environment variables
+            logger.info("Connecting to the Service Bus via a connection string.")
+            connection_str = os.getenv("SERVICE_BUS_CONNECTION_STR")
+            if not connection_str:
+                raise EnvironmentError("SERVICE_BUS_CONNECTION_STR is required when not using managed identity.")
+            logger.info("Using connection string for Service Bus authentication.")
+            client = ServiceBusClient.from_connection_string(connection_str)
 
         # Send message to topic
         with client:

--- a/src/function_apps/service_layer/service_layer/service_layer.py
+++ b/src/function_apps/service_layer/service_layer/service_layer.py
@@ -22,6 +22,8 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
         if not isinstance(payload, dict):
             return func.HttpResponse("Invalid payload format. Expected a JSON object.", status_code=HTTPStatus.BAD_REQUEST)
 
+        # Determine auth mode
+        use_managed_identity = os.getenv("USE_MANAGED_IDENTITY", "false").lower() == "true"
         topic_name = os.getenv("TOPIC_NAME")
 
         if not topic_name:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

To allow this docker / function app to run locally we need to enable it to use the service bus connection string. This was originally in the code, this PR puts it back in. 

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
